### PR TITLE
fix: adjust style to accommodate column size

### DIFF
--- a/frontend/app/ClientPage.tsx
+++ b/frontend/app/ClientPage.tsx
@@ -48,10 +48,10 @@ const ClientPage = () => {
   }, [activityLogs]);
 
   return (
-    <div className="flex flex-col gap-6 pb-10">
+    <div className="flex w-full flex-col gap-6 pb-10">
       <div className="flex gap-6 flex-col md:flex-row max-w-[1024px]">
         {/* Left board */}
-        <div className="flex flex-col gap-6 flex-1 max-w-none order-2 md:order-1 md:max-w-64">
+        <div className="flex flex-col gap-6 w-full order-2 md:order-1 lg:w-64 md:w-60">
           <Card title="photo">
             <Image
               className="w-full grayscale"
@@ -177,7 +177,7 @@ const ClientPage = () => {
           </Card>
         </div>
         {/* Center board */}
-        <div className="flex flex-col gap-6 flex-1 order-1 md:order-2">
+        <div className="flex flex-col gap-6 order-1 md:order-2 w-full md:w-0 md:flex-grow">
           <Card
             title="hello world!"
             actionBtnIcon={<UpRightArrowIcon />}
@@ -273,7 +273,7 @@ const ClientPage = () => {
           </Card>
         </div>
         {/* Right board */}
-        <div className="flex flex-col gap-[25px] flex-1 max-w-none order-3 md:order-3 md:max-w-64">
+        <div className="flex flex-col gap-[25px] w-full order-3 md:order-3 lg:w-64 md:w-60">
           <Card title="links">
             <div className="flex flex-col gap-4">
               <div className="flex gap-2 items-center">

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -76,6 +76,10 @@ h6 {
   @apply text-h6 font-medium;
 }
 
+pre {
+  overflow-x: auto;
+}
+
 /* Hack on twitter timeline iframe style */
 .twitter-timeline > iframe {
   width: 100% !important;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <main className="flex flex-col p-6 pt-10 pb-16 h-full items-center">
+        <main className="flex flex-col p-6 pt-10 pb-16 items-center">
           <Link className="text-6xl font-normal text-center mb-10" href="/">
             Sami
           </Link>


### PR DESCRIPTION
Activity log can involve `code` markdown, and it breaks layout frame. Needed to set column width exactly to fix that problem.

